### PR TITLE
feat: add CI / CD

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -1,9 +1,14 @@
-name: CI
+name: CD
 
 on:
   pull_request:
     branches:
       - main
+
+# on:
+#   push:
+#     branches:
+#       - main
 
 env:
   DOCKER_BUILDKIT: 1
@@ -12,8 +17,25 @@ env:
   CI_CONTAINER_IMAGE_NAME: ghcr.io/nmfr/sqlc-template/ci
 
 jobs:
-  test:
+  cache-ci-container-image:
     runs-on: ubuntu-22.04
+    permissions:
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: docker login
+        continue-on-error: true
+        run: (echo ${{ secrets.GITHUB_TOKEN }} | docker login ${CI_CONTAINER_REGISTRY} -u ${GITHUB_ACTOR} --password-stdin)
+      - name: docker build
+        run: make container run="echo 'image built'"
+      - name: docker push
+        continue-on-error: true
+        run: docker push $CI_CONTAINER_IMAGE_NAME
+
+  deploy:
+    runs-on: ubuntu-22.04
+    concurrency: ci-${{ github.ref }}
+    needs: cache-ci-container-image
     steps:
       - uses: actions/checkout@v4
       - name: docker login

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -1,14 +1,9 @@
 name: CD
 
 on:
-  pull_request:
+  push:
     branches:
       - main
-
-# on:
-#   push:
-#     branches:
-#       - main
 
 env:
   DOCKER_BUILDKIT: 1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+
+env:
+  DOCKER_BUILDKIT: 1
+  USE_CONTAINER_CACHE: true
+  CI_CONTAINER_REGISTRY: ghcr.io
+  CI_CONTAINER_IMAGE_NAME: ghcr.io/nmfr/sqlc-template/ci
+
+jobs:
+  test:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: docker login
+        continue-on-error: true
+        run: (echo ${{ secrets.GITHUB_TOKEN }} | docker login ${CI_CONTAINER_REGISTRY} -u ${GITHUB_ACTOR} --password-stdin)
+      # Needed so the container has permission to create files.
+      - name: container user repository file permissions
+        run: chmod -R o+rw .
+      - name: lint
+        run: make container run="make lint"
+      - name: tests
+        run: make container run="make test"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,6 +5,12 @@ on:
     tags:
       - "v*.*.*"
 
+env:
+  DOCKER_BUILDKIT: 1
+  USE_CONTAINER_CACHE: true
+  CI_CONTAINER_REGISTRY: ghcr.io
+  CI_CONTAINER_IMAGE_NAME: ghcr.io/nmfr/sqlc-template/ci
+
 jobs:
   create-release:
     runs-on: ubuntu-22.04
@@ -41,7 +47,7 @@ jobs:
             - name: sqlc-template
               wasm:
                 url: https://github.com/NMFR/sqlc-template/releases/download/'"${TAG}"'/sqlc-template.wasm
-                sha256: '$(sha256sum bin/sqlc-template.wasm | cut -f 1 -d ' ')''
+                sha256: '$(sha256sum bin/sqlc-template.wasm | cut -f 1 -d ' ')'
           ```
           ' \
             "bin/sqlc-template.wasm"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,5 +31,5 @@ jobs:
             --title="${GITHUB_REPOSITORY#*/} ${TAG#v}" \
             --generate-notes \
             --verify-tag \
-            --notes "sha256: `$(sha256sum bin/sqlc-template.wasm | cut -f 1 -d ' ')`\n\n``` yaml\nversion: '2'\nplugins:- name: sqlc-template\n  wasm:\n    url: https://github.com/${TAG}/sqlc-template.wasm\n    sha256: $(sha256sum bin/sqlc-template.wasm | cut -f 1 -d ' ')\n```" \
+            --notes "sha256: \`$(sha256sum bin/sqlc-template.wasm | cut -f 1 -d ' ')\`\n\n\`\`\` yaml\nversion: '2'\nplugins:- name: sqlc-template\n  wasm:\n    url: https://github.com/NMFR/sqlc-template/releases/download/${TAG}/sqlc-template.wasm\n    sha256: $(sha256sum bin/sqlc-template.wasm | cut -f 1 -d ' ')\n\`\`\`" \
             "bin/sqlc-template.wasm"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,6 +20,8 @@ jobs:
         run: chmod -R o+rw .
       - name: build
         run: make container run="make build"
+      - name: DEBUG
+        run: ls -lHa bin/
       - name: rename build artifact
         run: mv bin/sqlc-template.wasm "bin/sqlc-template.${TAG#v}.wasm"
       - name: Create release

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,12 +20,9 @@ jobs:
         run: chmod -R o+rw .
       - name: build
         run: make container run="make build"
-      - name: allow everyone to read write the build artifact folder
-        run: chmod -R o+rw bin/
-      - name: DEBUG
-        run: ls -lHa bin/
       - name: rename build artifact
-        run: mv bin/sqlc-template.wasm "bin/sqlc-template.${TAG#v}.wasm"
+        # rename from within the container due to file permission issues from the host.
+        run: make container run="mv bin/sqlc-template.wasm bin/sqlc-template.${TAG#v}.wasm"
       - name: Create release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,9 +22,6 @@ jobs:
         run: chmod -R o+rw .
       - name: build
         run: make container run="make build"
-      - name: rename build artifact
-        # rename from within the container due to file permission issues from the host.
-        run: make container run="mv bin/sqlc-template.wasm bin/sqlc-template.${TAG#v}.wasm"
       - name: Create release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -34,4 +31,4 @@ jobs:
             --title="${GITHUB_REPOSITORY#*/} ${TAG#v}" \
             --generate-notes \
             --verify-tag \
-            "bin/sqlc-template.${TAG#v}.wasm"
+            "bin/sqlc-template.wasm"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,6 +8,8 @@ on:
 jobs:
   create-release:
     runs-on: ubuntu-22.04
+    permissions:
+      contents: write
     env:
       TAG: ${{ github.ref_name }}
     steps:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,6 +20,8 @@ jobs:
         run: chmod -R o+rw .
       - name: build
         run: make container run="make build"
+      - name: allow everyone to read write the build artifact folder
+        run: chmod -R o+rw bin/
       - name: DEBUG
         run: ls -lHa bin/
       - name: rename build artifact

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,7 +6,7 @@ on:
       - "v*.*.*"
 
 jobs:
-  cache-ci-container-image:
+  create-release:
     runs-on: ubuntu-22.04
     env:
       TAG: ${{ github.ref_name }}
@@ -15,6 +15,9 @@ jobs:
       - name: docker login
         continue-on-error: true
         run: (echo ${{ secrets.GITHUB_TOKEN }} | docker login ${CI_CONTAINER_REGISTRY} -u ${GITHUB_ACTOR} --password-stdin)
+      # Needed so the container has permission to create files.
+      - name: container user repository file permissions
+        run: chmod -R o+rw .
       - name: build
         run: make container run="make build"
       - name: rename build artifact

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,5 +31,17 @@ jobs:
             --title="${GITHUB_REPOSITORY#*/} ${TAG#v}" \
             --generate-notes \
             --verify-tag \
-            --notes "sha256: \`$(sha256sum bin/sqlc-template.wasm | cut -f 1 -d ' ')\`\n\n\`\`\` yaml\nversion: '2'\nplugins:- name: sqlc-template\n  wasm:\n    url: https://github.com/NMFR/sqlc-template/releases/download/${TAG}/sqlc-template.wasm\n    sha256: $(sha256sum bin/sqlc-template.wasm | cut -f 1 -d ' ')\n\`\`\`" \
+            --notes 'sha256: `'$(sha256sum bin/sqlc-template.wasm | cut -f 1 -d ' ')'`
+
+          `sqlc.yaml` example:
+
+          ``` yaml
+          version: "2"
+          plugins:
+            - name: sqlc-template
+              wasm:
+                url: https://github.com/NMFR/sqlc-template/releases/download/'"${TAG}"'/sqlc-template.wasm
+                sha256: '$(sha256sum bin/sqlc-template.wasm | cut -f 1 -d ' ')''
+          ```
+          ' \
             "bin/sqlc-template.wasm"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,9 +26,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release create "$TAG" \
+          gh release create "${TAG}" \
             --repo="$GITHUB_REPOSITORY" \
             --title="${GITHUB_REPOSITORY#*/} ${TAG#v}" \
             --generate-notes \
             --verify-tag \
+            --notes "sha256: `$(sha256sum bin/sqlc-template.wasm | cut -f 1 -d ' ')`\n\n``` yaml\nversion: '2'\nplugins:- name: sqlc-template\n  wasm:\n    url: https://github.com/${TAG}/sqlc-template.wasm\n    sha256: $(sha256sum bin/sqlc-template.wasm | cut -f 1 -d ' ')\n```" \
             "bin/sqlc-template.wasm"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,31 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  cache-ci-container-image:
+    runs-on: ubuntu-22.04
+    env:
+      TAG: ${{ github.ref_name }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: docker login
+        continue-on-error: true
+        run: (echo ${{ secrets.GITHUB_TOKEN }} | docker login ${CI_CONTAINER_REGISTRY} -u ${GITHUB_ACTOR} --password-stdin)
+      - name: build
+        run: make container run="make build"
+      - name: rename build artifact
+        run: mv bin/sqlc-template.wasm "bin/sqlc-template.${TAG#v}.wasm"
+      - name: Create release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "$TAG" \
+            --repo="$GITHUB_REPOSITORY" \
+            --title="${GITHUB_REPOSITORY#*/} ${TAG#v}" \
+            --generate-notes \
+            --verify-tag \
+            "bin/sqlc-template.${TAG#v}.wasm"

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN \
   # Install the Golang protobuf compiler plugin.
   go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.31.0 && \
   # Install the golangci-lint linter.
-  curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.55.2 && \
+  curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.63.4 && \
   # Create the non root user and group.
   groupadd --gid ${GROUP_ID} ${GROUP_NAME} && \
   useradd --uid ${USER_ID} --gid ${GROUP_ID} --create-home ${USER_NAME} && \

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,7 @@ clean:
 build: clean generate-protobuf
 	mkdir -p bin
 	GOOS=wasip1 GOARCH=wasm go build -o bin/sqlc-template.wasm cmd/sqlc-template/main.go
+	sha256sum bin/sqlc-template.wasm > bin/sqlc-template.sha256
 
 # make container run="<command>" # Run a command from inside the container. Examples: `make container run="make spell-check"`.
 .PHONY: container

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ fmt:
 # make lint # Lint the code base searching for formatting or known bad patterns.
 .PHONY: lint
 lint:
-	golangci-lint run
+	GOFLAGS=-buildvcs=false golangci-lint run
 
 # make test # Run tests.
 .PHONY: test


### PR DESCRIPTION
Add Github actions workflows that automatically:
- Run the linter, tests and build on every commit pushed to a PR or to the `main` branch.
- Build and push the `ci` container stage to this repository registry to cache the `ci` container (so it doesn't have to build on every Github action triggered).
- Create a new Github release on every tag matching the `v*.*.*` pattern.

Additionally upgrade the `golangci-lint` version and add the `-buildvcs=false` flag to avoid the error:

``` sh
error obtaining VCS status: exit status 128
```

Caused by the git repository file ownership being different that the executing user.