### PR TITLE
feat: update to go 1.24.2

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,4 +1,24 @@
 # golangci-lint linter configuration.
 # See https://golangci-lint.run/usage/configuration/ for more information.
+version: "2"
 run:
   tests: false
+linters:
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Base stage, used to define the base image reference only once and to contain common tools used in other stages.
-FROM docker.io/golang:1.21.4-bookworm@sha256:85aacbed94a248f792beb89198649ddbc730649054b397f8d689e9c4c4cceab7 AS base
+FROM docker.io/golang:1.24.2-bookworm@sha256:00eccd446e023d3cd9566c25a6e6a02b90db3e1e0bbe26a48fc29cd96e800901 AS base
 
 # Fix: https://github.com/hadolint/hadolint/wiki/DL4006
 # Fix: https://github.com/koalaman/shellcheck/wiki/SC3014
@@ -36,7 +36,7 @@ RUN \
   # Install the Golang protobuf compiler plugin.
   go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.31.0 && \
   # Install the golangci-lint linter.
-  curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.63.4 && \
+  curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.1.2 && \
   # Create the non root user and group.
   groupadd --gid ${GROUP_ID} ${GROUP_NAME} && \
   useradd --uid ${USER_ID} --gid ${GROUP_ID} --create-home ${USER_NAME} && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -87,12 +87,12 @@ USER ${USER_NAME}
 
 # Install the VS Code Golang extension dependencies.
 RUN go install github.com/cweill/gotests/gotests@v1.6.0 && \
-  go install github.com/fatih/gomodifytags@v1.16.0 && \
-  go install github.com/josharian/impl@v1.1.0 && \
+  go install github.com/fatih/gomodifytags@v1.17.0 && \
+  go install github.com/josharian/impl@v1.4.0 && \
   go install github.com/haya14busa/goplay/cmd/goplay@v1.0.0 && \
-  go install github.com/go-delve/delve/cmd/dlv@v1.21.2 && \
-  go install honnef.co/go/tools/cmd/staticcheck@v0.4.6 && \
-  go install golang.org/x/tools/gopls@v0.14.2
+  go install github.com/go-delve/delve/cmd/dlv@v1.24.2 && \
+  go install honnef.co/go/tools/cmd/staticcheck@v0.6.1 && \
+  go install golang.org/x/tools/gopls@v0.18.1
 
 # Install Oh My Zsh for the non root user.
 RUN sh -c "$(curl -fsSL https://raw.github.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/NMFR/sqlc-template
 
-go 1.21.4
+go 1.24.2
 
 require (
 	github.com/Masterminds/sprig/v3 v3.3.0


### PR DESCRIPTION
Update:
- Go from 1.21.4 to 1.24.2.
- golangci-lint from v1.63.4 to v2.1.2.
- Update the VS Code Golang extension dependencies.